### PR TITLE
Allow resetting the device from within a test case

### DIFF
--- a/lib/device.js
+++ b/lib/device.js
@@ -80,6 +80,9 @@ class Device extends EventEmitter {
 			case 'enabled': req.t = 1; break;
 			case 'disabled': req.t = 0; break;
 		}
+		if (param.clearBackupMemory) {
+			req.b = 1;
+		}
 		await this._request(req);
 	}
 
@@ -145,6 +148,7 @@ class Device extends EventEmitter {
 		this._willDetach = true;
 		try {
 			await this._usbDev.updateFirmware(bin, { timeout: DEVICE_FLASH_TIMEOUT });
+			this.emit('reset');
 		} catch (err) {
 			this._willDetach = false;
 			throw err;
@@ -169,6 +173,7 @@ class Device extends EventEmitter {
 			}
 		} finally {
 			await this._close();
+			this.emit('reset');
 		}
 	}
 

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -56,6 +56,7 @@ class Runner {
 		this._tempDir = null; // Temp directory
 		this._runMode = null; // Run mode
 		this._patterns = null; // Test name patterns
+		this._currentTest = null; // Current test
 	}
 
 	async init() {
@@ -174,6 +175,10 @@ class Runner {
 		return ok;
 	}
 
+	get currentTest() {
+		return this._currentTest;
+	}
+
 	async _run() {
 		this._log.verbose('Generating test matrix');
 		this._initTestMatrix();
@@ -191,6 +196,7 @@ class Runner {
 		// Initialize the runner's context
 		const ctx = this._mocha.suite.ctx;
 		ctx.particle = {
+			runner: this,
 			deviceManager: this._devMgr,
 			apiClient: this._apiClient,
 			builder: this._builder,
@@ -351,11 +357,13 @@ class Runner {
 			this._log.unindent();
 		};
 		const testBegin = (test) => {
+			this._currentTest = test;
 			this._log.indent();
 			test.particle.startTime = Date.now();
 		};
 		const testEnd = (test) => {
 			this._log.unindent();
+			this._currentTest = null;
 		};
 		const testPass = (test) => {
 			// Print test duration for all passed tests

--- a/lib/suite.js
+++ b/lib/suite.js
@@ -52,6 +52,7 @@ class PlatformSuite {
 		this._log = log; // Logger instance
 		this._suite = suite; // Test suite
 		this._ctx = null; // Runner context
+		this._onDeviceReset = this._onDeviceReset.bind(this);
 	}
 
 	async init(ctx) {
@@ -94,10 +95,13 @@ class PlatformSuite {
 			if (!test.parent.particle.suiteInitialized) {
 				for (let dev of devs) {
 					this._deviceLog(dev).verbose('Initializing device test suite');
+					// Clear the application backup RAM when initializing the test suite for the first time
+					const param = { ...test.parent.particle, clearBackupMemory: !test.parent.particle.backupMemoryCleared };
 					const t1 = Date.now();
-					await dev.initSuite(test.parent.particle);
+					await dev.initSuite(param);
 					test.particle.suiteInitDuration += Date.now() - t1;
 				}
+				test.parent.particle.backupMemoryCleared = true;
 				test.parent.particle.suiteInitialized = true;
 			}
 			// Start the test on each device
@@ -257,11 +261,15 @@ class PlatformSuite {
 			this._ctx.devices.push(dev);
 			this._deviceLog(dev).verbose(`Target device: ${dev.displayName}`);
 		}
+		for (let dev of this._ctx.devices) {
+			dev.on('reset', this._onDeviceReset);
+		}
 	}
 
 	async _shutdownDevices() {
 		if (this._ctx.devices) {
 			for (let dev of this._ctx.devices) {
+				dev.off('reset', this._onDeviceReset);
 				try {
 					this._deviceLog(dev).verbose('Resetting device');
 					await dev.reset();
@@ -274,6 +282,13 @@ class PlatformSuite {
 			delete this._ctx.devices;
 		}
 		delete this._ctx.fixtures;
+	}
+
+	_onDeviceReset() {
+		const test = this._ctx.runner.currentTest;
+		if (test) {
+			test.parent.particle.suiteInitialized = false; // TODO: This should be a per-device flag
+		}
 	}
 
 	_deviceLog(dev) {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -253,15 +253,15 @@
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
     },
     "chai": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
-      "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.4.tgz",
+      "integrity": "sha512-yS5H68VYOCtN1cjfwumDSuzn/9c+yza4f3reKXlE5rUg7SFcCEy90gJvydNgOYtblyf4Zi6jIWRnXOgErta0KA==",
       "requires": {
         "assertion-error": "^1.1.0",
         "check-error": "^1.0.2",
         "deep-eql": "^3.0.1",
         "get-func-name": "^2.0.0",
-        "pathval": "^1.1.0",
+        "pathval": "^1.1.1",
         "type-detect": "^4.0.5"
       }
     },
@@ -1134,9 +1134,9 @@
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "pathval": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
-      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ=="
     },
     "picomatch": {
       "version": "2.0.7",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "start": "node lib/index.js"
   },
   "dependencies": {
-    "chai": "^4.2.0",
+    "chai": "^4.3.4",
     "chalk": "^2.4.2",
     "convict": "^5.1.0",
     "fast-glob": "^3.1.0",


### PR DESCRIPTION
This PR enables writing tests that require resetting the device, for example: https://github.com/particle-iot/device-os/pull/2312. Given that such tests often require storing some context data in the backup RAM, an additional logic has been added to clear the contents of the application backup RAM when a Device OS test suite is first initialized.