### PR TITLE
Add esomx, trackerm, p2 + eliminate duplicated data so new hardware platforms can easily be added 

### DIFF
--- a/lib/platform.js
+++ b/lib/platform.js
@@ -1,3 +1,4 @@
+const deviceConstants = require('@particle/device-constants');
 /**
  * Device OS platform.
  */
@@ -70,68 +71,24 @@ class Platform {
 /**
  * Supported Device OS platforms.
  */
-const PLATFORMS = [
-	{
-		id: 6,
-		name: 'photon',
-		displayName: 'Photon',
-		tags: ['photon', 'gen2', 'wifi', 'tcp']
-	},
-	{
-		id: 8,
-		name: 'p1',
-		displayName: 'P1',
-		tags: ['p1', 'gen2', 'wifi', 'tcp']
-	},
-	{
-		id: 10,
-		name: 'electron',
-		displayName: 'Electron',
-		tags: ['electron', 'gen2', 'cellular', 'udp']
-	},
-	{
-		id: 12,
-		name: 'argon',
-		displayName: 'Argon',
-		tags: ['argon', 'gen3', 'wifi', 'ble', 'udp']
-	},
-	{
-		id: 13,
-		name: 'boron',
-		displayName: 'Boron',
-		tags: ['boron', 'gen3', 'cellular', 'ble', 'udp']
-	},
-	// {
-	// 	id: 22,
-	// 	name: 'asom',
-	// 	displayName: 'A SoM',
-	// 	tags: ['asom', 'gen3', 'som', 'wifi', 'ble', 'udp']
-	// },
-	{
-		id: 23,
-		name: 'bsom',
-		displayName: 'B SoM',
-		tags: ['bsom', 'gen3', 'som', 'cellular', 'ble', 'udp']
-	},
-	{
-		id: 25,
-		name: 'b5som',
-		displayName: 'B5 SoM',
-		tags: ['b5som', 'gen3', 'som', 'cellular', 'ble', 'udp']
-	},
-	{
-		id: 26,
-		name: 'tracker',
-		displayName: 'Tracker',
-		tags: ['tracker', 'gen3', 'som', 'cellular', 'ble', 'udp', 'gps']
-	},
-	{
-		id: 32,
-		name: 'p2',
-		displayName: 'P2',
-		tags: ['p2', 'gen3', 'som', 'wifi', 'ble', 'udp']
-	},
-].map(p => new Platform(p));
+const platformConstructorObjects = [];
+for (const platformKey in deviceConstants) {
+	const { id, name, displayName, generation, features } = deviceConstants[platformKey];
+	if (generation < 2) {
+		continue;
+	}
+	const platformConstructorObject = {
+		id, name, displayName,
+		tags: [
+			name,
+			`gen${generation}`,
+			displayName,
+		]
+	};
+	platformConstructorObject.tags.push(...features);
+	platformConstructorObjects.push(platformConstructorObject);
+}
+const PLATFORMS = platformConstructorObjects.map(p => new Platform(p));
 
 const PLATFORMS_BY_ID = PLATFORMS.reduce((map, p) => map.set(p.id, p), new Map());
 const PLATFORMS_BY_NAME = PLATFORMS.reduce((map, p) => map.set(p.name, p), new Map());

--- a/lib/platform.js
+++ b/lib/platform.js
@@ -81,8 +81,7 @@ for (const platformKey in deviceConstants) {
 		id, name, displayName,
 		tags: [
 			name,
-			`gen${generation}`,
-			displayName,
+			`gen${generation}`
 		]
 	};
 	platformConstructorObject.tags.push(...features);

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -465,9 +465,9 @@
       "dev": true
     },
     "@particle/device-constants": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@particle/device-constants/-/device-constants-1.3.0.tgz",
-      "integrity": "sha512-OI7K5yEsN8R/ommsM0IiFfQSEN0NhPFelQGLKIQ+yNXUVvEsZOW18QdZirLreKIheIrqsZOhuqppDp0orykL6g=="
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@particle/device-constants/-/device-constants-1.7.0.tgz",
+      "integrity": "sha512-tRWR+uIGmpZP2V3BMdevn7ukrAJMmIpyttGMfGQbyJdRmpwr57MBv4HvHXVOUIWjIQcWKgk+V5kySHzycqleSg=="
     },
     "@protobufjs/aspromise": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "coverage": "nyc --check-coverage npm run test:unit"
   },
   "dependencies": {
-    "@particle/device-constants": "^1.3.0",
+    "@particle/device-constants": "^1.7.0",
     "chai": "^4.3.4",
     "chalk": "^2.4.2",
     "convict": "^5.1.0",

--- a/test/platform.spec.js
+++ b/test/platform.spec.js
@@ -1,0 +1,92 @@
+const sinon = require('sinon');
+const { expect } = require('./test');
+const { PLATFORMS, Platform, platformForName } = require('../lib/platform');
+
+describe('platform.js', () => {
+	beforeEach(async () => {
+	});
+
+	afterEach(async () => {
+		sinon.restore();
+	});
+
+	describe('PLATFORMS', () => {
+		it('is an array of Platform instances', () => {
+			expect(PLATFORMS).to.be.an('array');
+			expect(PLATFORMS.length).to.be.greaterThan(0);
+			expect(PLATFORMS[0]).to.be.an.instanceOf(Platform);
+		});
+	});
+
+	describe('expected tags for selected platforms', () => {
+		const expectedTags = {
+			// TODO: "som" is missing, add it to device-constants + update this test
+			p2: ['p2', 'gen3', /* TODO 'som',*/ 'wifi', 'ble', 'udp'],
+			// Note: device-constants provides "gnss", device-os-test-runner provided "gps"
+			// let's use "gnss" instead because it's a more accurate reflection of reality.
+			// device-os integration tests don't use "gps" tag https://github.com/particle-iot/device-os/tree/develop/user/tests/integration
+			// So no action needed
+			tracker: ['tracker', 'gen3', 'som', 'cellular', 'ble', 'udp', 'gnss'],
+			// Note: added mesh device to make it pass
+			b5som: ['b5som', 'gen3', 'som', 'cellular', 'ble', 'udp', 'mesh'],
+			// Note: Added mesh
+			bsom: ['bsom', 'gen3', 'som', 'cellular', 'ble', 'udp', 'mesh'],
+			// Note: Added mesh
+			boron: ['boron', 'gen3', 'cellular', 'ble', 'udp', 'mesh'],
+			// Note: Added mesh
+			argon: ['argon', 'gen3', 'wifi', 'ble', 'udp', 'mesh'],
+			electron: ['electron', 'gen2', 'cellular', 'udp'],
+			p1: ['p1', 'gen2', 'wifi', 'tcp'],
+			photon: ['photon', 'gen2', 'wifi', 'tcp']
+
+		};
+		it('provides all expected data for p2', () => {
+			const p2 = platformForName('p2');
+			expect(p2).to.be.an.instanceOf(Platform);
+			expect(p2.id).to.eql(32);
+			expect(p2.name).to.eql('p2');
+			expect(p2.displayName).to.eql('P2');
+			expect(p2.tags).to.have.members(expectedTags.p2);
+		});
+
+		it('provides correct tags for tracker', () => {
+			const p = platformForName('tracker');
+			expect(p.tags).to.have.members(expectedTags.tracker);
+		});
+
+		it('provides correct tags for b5som', () => {
+			const p = platformForName('b5som');
+			expect(p.tags).to.have.members(expectedTags.b5som);
+		});
+
+		it('provides correct tags for bsom', () => {
+			const p = platformForName('bsom');
+			expect(p.tags).to.have.members(expectedTags.bsom);
+		});
+
+		it('provides correct tags for boron', () => {
+			const p = platformForName('boron');
+			expect(p.tags).to.have.members(expectedTags.boron);
+		});
+
+		it('provides correct tags for argon', () => {
+			const p = platformForName('argon');
+			expect(p.tags).to.have.members(expectedTags.argon);
+		});
+
+		it('provides correct tags for electron', () => {
+			const p = platformForName('electron');
+			expect(p.tags).to.have.members(expectedTags.electron);
+		});
+
+		it('provides correct tags for p1', () => {
+			const p = platformForName('p1');
+			expect(p.tags).to.have.members(expectedTags.p1);
+		});
+
+		it('provides correct tags for photon', () => {
+			const p = platformForName('photon');
+			expect(p.tags).to.have.members(expectedTags.photon);
+		});
+	});
+});

--- a/test/platform.spec.js
+++ b/test/platform.spec.js
@@ -20,25 +20,15 @@ describe('platform.js', () => {
 
 	describe('expected tags for selected platforms', () => {
 		const expectedTags = {
-			// TODO: "som" is missing, add it to device-constants + update this test
-			p2: ['p2', 'gen3', /* TODO 'som',*/ 'wifi', 'ble', 'udp'],
-			// Note: device-constants provides "gnss", device-os-test-runner provided "gps"
-			// let's use "gnss" instead because it's a more accurate reflection of reality.
-			// device-os integration tests don't use "gps" tag https://github.com/particle-iot/device-os/tree/develop/user/tests/integration
-			// So no action needed
+			p2: ['p2', 'gen3', 'wifi', 'ble', 'udp'],
 			tracker: ['tracker', 'gen3', 'som', 'cellular', 'ble', 'udp', 'gnss'],
-			// Note: added mesh device to make it pass
 			b5som: ['b5som', 'gen3', 'som', 'cellular', 'ble', 'udp', 'mesh'],
-			// Note: Added mesh
 			bsom: ['bsom', 'gen3', 'som', 'cellular', 'ble', 'udp', 'mesh'],
-			// Note: Added mesh
 			boron: ['boron', 'gen3', 'cellular', 'ble', 'udp', 'mesh'],
-			// Note: Added mesh
 			argon: ['argon', 'gen3', 'wifi', 'ble', 'udp', 'mesh'],
 			electron: ['electron', 'gen2', 'cellular', 'udp'],
 			p1: ['p1', 'gen2', 'wifi', 'tcp'],
 			photon: ['photon', 'gen2', 'wifi', 'tcp']
-
 		};
 		it('provides all expected data for p2', () => {
 			const p2 = platformForName('p2');


### PR DESCRIPTION
## Overview

Adds support for `esomx` and `trackerm` platforms. Also adjusts code so that future hardware platforms will not require custom modifications, but rather, just a simple update of `@particle/device-constants` version and a re-release.

The approach to eliminating duplicated hardware platform `tags` metadata was to depend on device-constants `features` data directly and transforming the data slightly to comply with the internal data structures in platform.js.

See [sc-98440](https://app.shortcut.com/particle/story/98440/move-definitions-specific-to-device-os-test-runner-to-device-constants-npm-module#activity-104446) for more details.

## How to test?

Observe the new unit tests that cover the expected tags for each platform. Some of these tags are used in DVOS integration tests here: https://github.com/particle-iot/device-os/tree/develop/user/tests/integration

1. `git checkout sc-98440/make-platforms-depend-on-device-constants`
2. `npm i`
3. `npm test`

Observe that `esomx`, `trackerm`, and `p2` args can be passed to a build command like this: (you'll need to modify the args to match actual location of device-os on your machine)

```
node ./lib/index.js --test-dir /Users/jgoggins/git/particle/firmware-private/user/tests/integration/communication/events/ --device-os-dir /Users/jgoggins/git/particle/firmware-private build esomx -v
```

This command should fail in way that clearly illustrates that the `esomx` arg was accepted and that the `make` system of device-os got executed. Instead of `Error: Unrecognized filtering option: bonk`, you should see something like this:

```
Error: `make` failed with the exit code 2:
```
