### PR TITLE
device: increase DEVICE_OPEN_TIMEOUT to 1 min

### DIFF
--- a/lib/device.js
+++ b/lib/device.js
@@ -9,7 +9,7 @@ const usb = require('usb');
 const EventEmitter = require('events');
 const fs = require('fs');
 
-const DEVICE_OPEN_TIMEOUT = 30000;
+const DEVICE_OPEN_TIMEOUT = 60000;
 const DEVICE_OPEN_RETRIES = 2;
 const DEVICE_OPEN_MIN_RETRY_DELAY = 300;
 const DEVICE_OPEN_MAX_RETRY_DELAY = 1000;


### PR DESCRIPTION
Increase DEVICE_OPEN_TIMEOUT to 1 min as some flashing operations may take over 30s on particular platforms while in bootloader.