### PR TITLE
[device] Fix re-attachment issue

### DIFF
--- a/lib/device.js
+++ b/lib/device.js
@@ -9,8 +9,8 @@ const usb = require('usb').usb;
 const EventEmitter = require('events');
 const fs = require('fs');
 
-const DEVICE_OPEN_TIMEOUT = 60000;
-const DEVICE_OPEN_RETRIES = 2;
+const DEVICE_OPEN_TIMEOUT = 90000;
+const DEVICE_OPEN_RETRIES = 3;
 const DEVICE_OPEN_MIN_RETRY_DELAY = 300;
 const DEVICE_OPEN_MAX_RETRY_DELAY = 1000;
 const DEVICE_DELAY_AFTER_ATTACH = 1000;
@@ -124,29 +124,31 @@ class Device extends EventEmitter {
 				throw new Error('Test timeout');
 			}
 
-			try {
-				const mbox = await this.readMailbox();
-				if (mbox) {
-					this._log.debug('Mailbox message', mbox);
-					if (mbox.t && mbox.t === MailboxTypes.RESET_PENDING) {
-						this._log.verbose('Device test notified about expected reset');
-						this._willDetach = true;
-						expectingReset = true;
-						mboxMessages.push(mbox);
-						await this.close();
-					} else if (mbox.t && mbox.t === MailboxTypes.SAFE_MODE_PENDING) {
-						this._log.verbose('Device test notified about expected safe mode');
-						this._willDetach = true;
-						expectingSafeMode = true;
-						expectingReset = true;
-						mboxMessages.push(mbox);
-						await this.close();
-					} else if (mbox.t) {
-						mboxMessages.push(mbox);
+			if (!expectingSafeMode && !expectingReset) {
+				try {
+					const mbox = await this.readMailbox();
+					if (mbox) {
+						this._log.debug('Mailbox message', mbox);
+						if (mbox.t && mbox.t === MailboxTypes.RESET_PENDING) {
+							this._log.info('Device test notified about expected reset');
+							this.setWillDetach(true);
+							expectingReset = true;
+							mboxMessages.push(mbox);
+							await this.close();
+						} else if (mbox.t && mbox.t === MailboxTypes.SAFE_MODE_PENDING) {
+							this._log.info('Device test notified about expected safe mode');
+							this.setWillDetach(true);
+							expectingSafeMode = true;
+							expectingReset = true;
+							mboxMessages.push(mbox);
+							await this.close();
+						} else if (mbox.t) {
+							mboxMessages.push(mbox);
+						}
 					}
+				} catch (err) {
+					this._log.debug('Failed to receive mailbox message');
 				}
-			} catch (err) {
-				this._log.debug('Failed to receive mailbox message');
 			}
 
 			let rep = null;
@@ -163,9 +165,18 @@ class Device extends EventEmitter {
 					rep = { result: RequestResult.STATUS_RUNNING };
 					// TODO: check device mode? Problem with that is that the request may not succeed due to device
 					// resetting to apply firmware update etc. For now, always expecting a reset.
-					this._willDetach = true;
+					this.setWillDetach(true);
 				} else {
-					throw err;
+					// FIXME: we may sometimes get 'Timeout while opening the device' exception even though
+					// the device should already be openable. Close and retry until test timeout.
+					// Alternatively we may try resetting it as well, but that may cause issues for the tests
+					// as an expected reset may be a sleep call instead.
+					if ((expectingReset || expectingSafeMode) && err.message.includes('Timeout while opening')) {
+						await this.close();
+						rep = { result: RequestResult.STATUS_RUNNING };
+					} else {
+						throw err;
+					}
 				}
 			}
 			const dt = Date.now() - t1;
@@ -184,8 +195,9 @@ class Device extends EventEmitter {
 						break;
 					}
 					case RequestResult.STATUS_WAITING: {
-						if (expectingReset) {
+						if (expectingReset || expectingSafeMode) {
 							testResult = TestResult.PASSED;
+							this.setWillDetach(false);
 							break;
 						}
 						/* falls through */
@@ -224,12 +236,12 @@ class Device extends EventEmitter {
 		const bin = fs.readFileSync(binFile);
 		await this._open();
 		await this._usbDev.disconnectFromCloud({ force: true });
-		this._willDetach = true;
+		this.setWillDetach(true);
 		try {
 			await this._usbDev.updateFirmware(bin, { timeout: DEVICE_FLASH_TIMEOUT });
 			this.emit('reset');
 		} catch (err) {
-			this._willDetach = false;
+			this.setWillDetach(false);
 			throw err;
 		}
 		await this._close();
@@ -238,7 +250,7 @@ class Device extends EventEmitter {
 	async reset() {
 		await this._open();
 		try {
-			this._willDetach = true;
+			this.setWillDetach(true);
 			await this._usbDev.reset({ timeout: DEVICE_RESET_TIMEOUT });
 		} catch (err) {
 			if (err instanceof particleUsb.UsbError) {
@@ -265,7 +277,7 @@ class Device extends EventEmitter {
 			if (attached) {
 				this._lastAttach = Date.now();
 			} else {
-				this._willDetach = false;
+				this.setWillDetach(false);
 				if (this._usbDev && this._usbDev.isOpen) {
 					this._needClose = true;
 				}
@@ -332,7 +344,7 @@ class Device extends EventEmitter {
 				throw new RunnerError(`Runner command failed, code: ${rep.result}`, rep.result);
 			}
 			if (rep.result === RequestResult.RESET_PENDING) {
-				this._willDetach = true;
+				this.setWillDetach(true);
 				close = true;
 			}
 			return rep;
@@ -349,7 +361,7 @@ class Device extends EventEmitter {
 	}
 
 	async _open() {
-		const timeoutAt = Date.now() + DEVICE_OPEN_TIMEOUT;
+		let timeoutAt = Date.now() + DEVICE_OPEN_TIMEOUT;
 		const canOpen = () => (!this._opening && !this._closing);
 		while (!canOpen()) {
 			const p = new Promise((resolve, reject) => {
@@ -376,6 +388,7 @@ class Device extends EventEmitter {
 		this._opening = true;
 		this.emit('_opening', true);
 		try {
+			let retries = DEVICE_OPEN_RETRIES;
 			const isAttached = () => (this._attached && !this._willDetach);
 			while (!isAttached()) {
 				const p = new Promise((resolve, reject) => {
@@ -399,9 +412,21 @@ class Device extends EventEmitter {
 				} catch (err) {
 					if (this._attached) {
 						// Next time, do not wait for the device to reattach
-						this._willDetach = false;
+						this.setWillDetach(false);
 					}
-					throw err;
+					// Try once more
+					// XXX: There seems to be some kind of a problem at least on HIL that prevents
+					// devices from being recognized as re-attached unless we close. Once done,
+					// they immediately get picked up as attached by node-usb.
+					if (this._usbDev) {
+						await this._usbDev.close({ processPendingRequests: false });
+						this._usbDev = null;
+					}
+					if (retries--) {
+						timeoutAt = Date.now() + DEVICE_OPEN_TIMEOUT;
+					} else {
+						throw err;
+					}
 				}
 			}
 			if (this._needClose) {


### PR DESCRIPTION
Adds a couple of workarounds for an issue with tests that involve resets or safe mode (e.g. `ota/assets`). The devices are not reported to be reattached after a reset for some reason by `node-usb`. With the changes below tests seems to be now passing fine.