### PR TITLE
Add an option to disable flashing of firmware binaries

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -215,6 +215,11 @@ const config = convict({
 		doc: 'Run mode',
 		format: Object.values(RunMode),
 		default: RunMode.NORMAL
+	},
+	noFlash: {
+		doc: 'Do not flash firmware binaries',
+		format: Boolean,
+		default: false
 	}
 });
 
@@ -322,7 +327,10 @@ function loadCliProfile() {
 function parseCmdLine() {
 	return parseArgs(process.argv.slice(2), {
 		string: ['_', 'grep', 'config-file', 'test-dir', 'binary-dir', 'device-os-dir', 'target-dir', 'report-file'],
-		boolean: ['build', 'dry', 'fixtures', 'tags', 'combine', 'version', 'help', 'json', 'verbose'],
+		boolean: ['build', 'dry', 'fixtures', 'tags', 'combine', 'version', 'help', 'json', 'verbose', 'flash'],
+		default: {
+			'flash': true
+		},
 		alias: {
 			'grep': 'g',
 			'config-file': 'c',
@@ -454,6 +462,8 @@ function updateConfig(args) {
 		config.set('logLevel', LogLevel.VERBOSE);
 		config.set('verbose', true);
 	}
+	// Whether to build and flash firmware binaries
+	config.set('noFlash', !args['flash']);
 }
 
 function loadConfigFiles(args) {

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -210,6 +210,7 @@ class Runner {
 			binaryDir: this._binaryDir,
 			tempDir: this._tempDir.name,
 			dryRun: this._runMode === RunMode.DRY_RUN,
+			noFlash: config.get('noFlash'),
 			log: this._log,
 			// Convenience functions
 			receiveEvent: (...args) => this._apiClient.receiveEvent(...args),

--- a/lib/suite.js
+++ b/lib/suite.js
@@ -59,8 +59,10 @@ class PlatformSuite {
 		// Initialize devices under test
 		await this._initDevices();
 		if (!this._ctx.dryRun) {
-			// Build and flash application binaries
-			await this._flashApps();
+			if (!this._ctx.noFlash) {
+				// Build and flash application binaries
+				await this._flashApps();
+			}
 			// Add device tests to the suite
 			await this._updateTests();
 		} else {


### PR DESCRIPTION
Add a command line option `--no-flash` that makes the runner skip the building and flashing steps when running tests. The option is hidden as using it may produce surprising results.