### PR TITLE
Do not try to convert event data to a number

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -132,15 +132,11 @@ class ApiClient {
 			const handlers = this._handlers.get(name);
 			if (handlers) {
 				if (data.length) {
-					let val = data[0];
-					const intVal = Number.parseInt(val);
-					if (!Number.isNaN(intVal)) {
-						val = intVal;
-					}
+					const d = data[0];
 					let received = false;
 					handlers.forEach(h => {
 						if (h.resolve) {
-							h.resolve(val);
+							h.resolve(d);
 							h.resolve = null;
 							h.reject = null;
 							clearTimeout(h.timer);


### PR DESCRIPTION
For some reason, the `receiveEvent()` helper function tries to convert the received event data to a number which may produce surprising results in integration tests. This PR removes that logic so that the event data is always a string.