### PR TITLE
Adds uhubctl hub.port cycling for error cases

### DIFF
--- a/lib/device.js
+++ b/lib/device.js
@@ -10,6 +10,8 @@ const usb = require('usb').usb;
 const EventEmitter = require('events');
 const fs = require('fs');
 
+const { cycleUSBwithPortPath } = require('./hub-cycle');
+
 const DEVICE_OPEN_TIMEOUT = 90000;
 const DEVICE_OPEN_RETRIES = 3;
 const DEVICE_OPEN_MIN_RETRY_DELAY = 300;
@@ -428,6 +430,9 @@ class Device extends EventEmitter {
 					// they immediately get picked up as attached by node-usb.
 					if (this._usbDev) {
 						await this._usbDev.close({ processPendingRequests: false });
+						await cycleUSBwithPortPath(this._portPath, { delaySec: 2 })
+							.then(() => this._log.info('[1] Cycled USB hub.port device is attached to'))
+							.catch(err => this._log.error('[1] Cycle USB failed:', err.message));
 						this._usbDev = null;
 					}
 					if (retries--) {
@@ -459,11 +464,17 @@ class Device extends EventEmitter {
 						const devs = await particleUsb.getDevices();
 						dev = devs.find(dev => usbDevicePortPath(dev.usbDevice.internalObject) === this._portPath);
 						if (!dev) {
+							await cycleUSBwithPortPath(this._portPath, { delaySec: 2 })
+								.then(() => this._log.info('[2a] Cycled USB hub.port device is attached to'))
+								.catch(err => this._log.error('[2a] Cycle USB failed:', err.message));
 							throw new Error('Device not found');
 						}
 						await dev.open();
 						if (this._needClose) {
 							this._needClose = false;
+							await cycleUSBwithPortPath(this._portPath, { delaySec: 2 })
+								.then(() => this._log.info('[2b] Cycled USB hub.port device is attached to'))
+								.catch(err => this._log.error('[2b] Cycle USB failed:', err.message));
 							throw new Error('Device not found');
 						}
 						this._usbDev = dev;
@@ -471,6 +482,9 @@ class Device extends EventEmitter {
 					} catch (err) {
 						if (dev) {
 							await dev.close({ processPendingRequests: false });
+							await cycleUSBwithPortPath(this._portPath, { delaySec: 2 })
+								.then(() => this._log.info('[2c] Cycled USB hub.port device is attached to'))
+								.catch(err => this._log.error('[2c] Cycle USB failed:', err.message));
 						}
 						if (!retries) {
 							throw err;
@@ -508,6 +522,20 @@ class Device extends EventEmitter {
 		try {
 			if (this._usbDev) {
 				await this._usbDev.close({ processPendingRequests: false });
+
+				// DEBUG: Leaving this here in case we need it in the future.
+				//        I tested leaving this in, and cycling ports every
+				//        time they close, but would get some errors rarely
+				//        such as "Unable to get serial number descriptor",
+				//        which seemed like a result of the device reattaching
+				//        just before the device serial was required.
+				//
+				//        If any stuck open/closed port should appear again,
+				//        enabling this again might be a good test.
+				//
+				// await cycleUSBwithPortPath(this._portPath, { delaySec: 2 })
+				// 	.then(() => this._log.info('[3] Cycled USB hub.port device is attached to'))
+				// 	.catch(err => this._log.error('[3] Cycle USB failed:', err.message));
 			}
 		} finally {
 			this._needClose = false;

--- a/lib/hub-cycle.js
+++ b/lib/hub-cycle.js
@@ -1,5 +1,5 @@
 'use strict';
-const { execCommand } = require('./util');
+const util = require('./util');
 
 function parseHubAndPort(portPath) {
 	const lastDot = portPath.lastIndexOf('.');
@@ -14,7 +14,7 @@ function parseHubAndPort(portPath) {
 
 async function isUhubctlInstalled() {
 	try {
-		const result = await execCommand('which', ['uhubctl']);
+		const result = await util.execCommand('which', ['uhubctl']);
 		return result.code === 0;
 	} catch {
 		return false;
@@ -34,7 +34,7 @@ async function cycleUSBwithPortPath(portPath, { delaySec = 2 } = {}) {
 	}
 
 	const { hub, port } = parseHubAndPort(portPath);
-	const result = await execCommand('uhubctl',
+	const result = await util.execCommand('uhubctl',
 		['-l', hub, '-p', port, '-a', 'cycle', '-d', String(delaySec)]
 	);
 
@@ -43,4 +43,4 @@ async function cycleUSBwithPortPath(portPath, { delaySec = 2 } = {}) {
 	}
 }
 
-module.exports = { cycleUSBwithPortPath };
+module.exports = { parseHubAndPort, isUhubctlInstalled, cycleUSBwithPortPath };

--- a/lib/hub-cycle.js
+++ b/lib/hub-cycle.js
@@ -1,0 +1,46 @@
+'use strict';
+const { execCommand } = require('./util');
+
+function parseHubAndPort(portPath) {
+	const lastDot = portPath.lastIndexOf('.');
+	if (lastDot === -1) {
+		throw new Error(`Invalid portPath format: ${portPath}`);
+	}
+	const hub = portPath.slice(0, lastDot);
+	const port = portPath.slice(lastDot + 1);
+
+	return { hub, port };
+}
+
+async function isUhubctlInstalled() {
+	try {
+		const result = await execCommand('which', ['uhubctl']);
+		return result.code === 0;
+	} catch {
+		return false;
+	}
+}
+
+// Cycle the USB hub port with uhubctl
+async function cycleUSBwithPortPath(portPath, { delaySec = 2 } = {}) {
+	if (!portPath) {
+		throw new Error('USB portPath required');
+	}
+
+	const hasUhubctl = await isUhubctlInstalled();
+	if (!hasUhubctl) {
+		console.error('uhubctl is not installed. Skipping USB hub cycle. Install from: https://github.com/mvp/uhubctl');
+		return;
+	}
+
+	const { hub, port } = parseHubAndPort(portPath);
+	const result = await execCommand('uhubctl',
+		['-l', hub, '-p', port, '-a', 'cycle', '-d', String(delaySec)]
+	);
+
+	if (result.code !== 0) {
+		throw new Error(`uhubctl failed with code ${result.code}: ${result.stdout}`);
+	}
+}
+
+module.exports = { cycleUSBwithPortPath };

--- a/lib/hub-cycle.test.js
+++ b/lib/hub-cycle.test.js
@@ -1,0 +1,101 @@
+'use strict';
+const { expect } = require('chai');
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+const chai = require('chai');
+chai.use(sinonChai);
+
+const util = require('./util');
+
+describe('hub-cycle', () => {
+	const fakePortPath = '3-3.4.2';
+	let hubCycle;
+
+	beforeEach(() => {
+		delete require.cache[require.resolve('./hub-cycle')];
+		hubCycle = require('./hub-cycle');
+	});
+
+	afterEach(async () => {
+		sinon.restore();
+	});
+
+	it('provides parseHubAndPort()');
+	it('provides isUhubctlInstalled()');
+	it('provides cycleUSBwithPortPath()');
+
+	describe('parseHubAndPort', () => {
+		it('converts port path to hub and port', () => {
+			expect(hubCycle.parseHubAndPort(fakePortPath)).to.eql({ hub: '3-3.4', port: '2' });
+		});
+
+		it('throws error for invalid port path without dot', () => {
+			expect(() => hubCycle.parseHubAndPort('3-3')).to.throw('Invalid portPath format: 3-3');
+		});
+	});
+
+	describe('isUhubctlInstalled', () => {
+		it('returns true when uhubctl is found', async () => {
+			sinon.stub(util, 'execCommand').resolves({ code: 0, stdout: '/usr/sbin/uhubctl' });
+			const result = await hubCycle.isUhubctlInstalled();
+			expect(result).to.be.true;
+			expect(util.execCommand).to.have.been.calledWith('which', ['uhubctl']);
+		});
+
+		it('returns false when uhubctl is not found', async () => {
+			sinon.stub(util, 'execCommand').resolves({ code: 1, stdout: '' });
+			const result = await hubCycle.isUhubctlInstalled();
+			expect(result).to.be.false;
+		});
+
+		it('returns false when execCommand throws an error', async () => {
+			sinon.stub(util, 'execCommand').rejects(new Error('Command failed'));
+			const result = await hubCycle.isUhubctlInstalled();
+			expect(result).to.be.false;
+		});
+	});
+
+	describe('cycleUSBwithPortPath', () => {
+		it('cycles USB port when uhubctl is installed', async () => {
+			const execStub = sinon.stub(util, 'execCommand');
+			execStub.withArgs('which', ['uhubctl']).resolves({ code: 0, stdout: '/usr/sbin/uhubctl' });
+			execStub.withArgs('uhubctl', sinon.match.array).resolves({ code: 0, stdout: 'Success' });
+
+			await hubCycle.cycleUSBwithPortPath(fakePortPath, { delaySec: 2 });
+
+			expect(execStub).to.have.been.calledWith('uhubctl',
+				['-l', '3-3.4', '-p', '2', '-a', 'cycle', '-d', '2']);
+		});
+
+		it('logs error and returns when uhubctl is not installed', async () => {
+			sinon.stub(util, 'execCommand').resolves({ code: 1, stdout: '' });
+			const consoleStub = sinon.stub(console, 'error');
+
+			await hubCycle.cycleUSBwithPortPath(fakePortPath);
+
+			expect(consoleStub).to.have.been.calledWith(sinon.match(/uhubctl is not installed/));
+		});
+
+		it('throws error when uhubctl fails', async () => {
+			const execStub = sinon.stub(util, 'execCommand');
+			execStub.withArgs('which', ['uhubctl']).resolves({ code: 0, stdout: '/usr/sbin/uhubctl' });
+			execStub.withArgs('uhubctl', sinon.match.array).resolves({ code: 1, stdout: 'Error output' });
+
+			try {
+				await hubCycle.cycleUSBwithPortPath(fakePortPath);
+				expect.fail('Should have thrown an error');
+			} catch (err) {
+				expect(err.message).to.match(/uhubctl failed with code 1/);
+			}
+		});
+
+		it('throws error when portPath is not provided', async () => {
+			try {
+				await hubCycle.cycleUSBwithPortPath(null);
+				expect.fail('Should have thrown an error');
+			} catch (err) {
+				expect(err.message).to.equal('USB portPath required');
+			}
+		});
+	});
+});


### PR DESCRIPTION
# Problem

- Device OS Test Runner was stalling on [particle-usb](https://github.com/particle-iot/particle-usb/pull/124) close.  Once this is fixed though, USB port is still in a bad state and needs to be cycled (re-enumerated).

# Solution

- add uhubctl cycle module
- add to various error cases after close
- note, this does not cut power to VBUS or reset the USB device, but does appear to re-enumerate the port which should help these error cases
- right after I added this and attempted to test it in the stalled condition, the issue stopped reproducing for about 30 runs.  I didn't see this being run either.  So we'll have to wait to see if this recovers an already running job.  Device will recover on next test when debugger resets the device though.
- I have force tested this and it works fine (see commented out cycleUSBwithPortPath)

# Reference

- https://app.shortcut.com/particle/story/135822/hil-rig-test-stalls-without-timing-out#activity-137077
- Here is a working test run with particle-usb / device-os-test-runner force updated in the docker container (this PR) : https://concourse.hil.particle.io/teams/particle/pipelines/device-os-test/jobs/device-os-test-22-us-brett/builds/128
- particle-usb PR: https://github.com/particle-iot/particle-usb/pull/124