### PR TITLE
Detailed mocha summary after retries (including errors), JSON reports

### DIFF
--- a/lib/report-builder.js
+++ b/lib/report-builder.js
@@ -1,0 +1,218 @@
+'use strict';
+
+const path = require('path');
+
+class ReportBuilder {
+	build(allReportData) {
+		const devices = new Map();
+		let totalTests = 0;
+		let totalPasses = 0;
+		let totalFailures = 0;
+		let totalSkipped = 0;
+		let totalDuration = 0;
+		const startTime = allReportData[0] && allReportData[0].start;
+		const endTime = allReportData[allReportData.length - 1] && allReportData[allReportData.length - 1].end;
+		const suiteNames = new Set();
+
+		for (const runData of allReportData) {
+			if (!runData || !runData.tests) {
+				continue;
+			}
+			for (const test of runData.tests) {
+				totalTests++;
+				if (test.state === 'passed') {
+					totalPasses++;
+				} else if (test.state === 'failed') {
+					totalFailures++;
+				} else if (test.state === 'skipped') {
+					totalSkipped++;
+				}
+				if (test.duration) {
+					totalDuration += test.duration;
+				}
+
+				const suiteInfo = this._extractSuiteInfo(test);
+				if (suiteInfo.file) {
+					suiteNames.add(suiteInfo.file);
+				}
+
+				const particle = test.particle || {};
+				const deviceList = particle.devices && particle.devices.length
+					? particle.devices
+					: [{ id: suiteInfo.platform || 'unknown', name: null, platform: suiteInfo.platform || null }];
+
+				for (const dev of deviceList) {
+					const devKey = dev.id || 'unknown';
+					const devPlatform = typeof dev.platform === 'object' && dev.platform !== null
+						? dev.platform.name
+						: (dev.platform || suiteInfo.platform || null);
+					if (!devices.has(devKey)) {
+						devices.set(devKey, {
+							id: devKey,
+							name: dev.name || null,
+							platform: devPlatform,
+							fixture: suiteInfo.fixture || null,
+							_suites: new Map()
+						});
+					}
+					const device = devices.get(devKey);
+
+					const suiteKey = suiteInfo.file || 'unknown';
+					if (!device._suites.has(suiteKey)) {
+						device._suites.set(suiteKey, {
+							name: suiteInfo.suiteName,
+							path: suiteInfo.suitePath,
+							file: suiteInfo.file,
+							retries: suiteInfo.retries,
+							_configurations: new Map()
+						});
+					}
+					const suite = device._suites.get(suiteKey);
+
+					const configKey = `${suiteInfo.systemThread}|${suiteInfo.systemMode}`;
+					if (!suite._configurations.has(configKey)) {
+						suite._configurations.set(configKey, {
+							systemThread: suiteInfo.systemThread,
+							systemMode: suiteInfo.systemMode,
+							_attempts: new Map()
+						});
+					}
+					const config = suite._configurations.get(configKey);
+
+					const attemptNum = runData.attempt || 1;
+					if (!config._attempts.has(attemptNum)) {
+						config._attempts.set(attemptNum, {
+							attempt: attemptNum,
+							passed: true,
+							tests: []
+						});
+					}
+					const attempt = config._attempts.get(attemptNum);
+
+					const particle = test.particle || {};
+					let duration = test.duration || 0;
+					if (!duration && particle.startTime && particle.endTime) {
+						duration = particle.endTime - particle.startTime;
+					}
+					const testData = {
+						name: particle.originalTitle || test.title || test.name || '',
+						duration,
+						state: test.state || (test.pending ? 'skipped' : 'unknown')
+					};
+					if (test.err) {
+						const err = { message: test.err.message || String(test.err) };
+						if (test.err.stack) {
+							err.stack = test.err.stack;
+						}
+						testData.err = err;
+					}
+					attempt.tests.push(testData);
+					if (test.state !== 'passed' && test.state !== 'skipped') {
+						attempt.passed = false;
+					}
+				}
+			}
+		}
+
+		const devicesArray = Array.from(devices.values()).map(device => {
+			const suites = Array.from(device._suites.values()).map(suite => {
+				const configurations = Array.from(suite._configurations.values()).map(config => {
+					const attempts = Array.from(config._attempts.values()).sort((a, b) => a.attempt - b.attempt);
+					return {
+						systemThread: config.systemThread,
+						systemMode: config.systemMode,
+						attempts
+					};
+				});
+				return {
+					name: suite.name,
+					path: suite.path,
+					file: suite.file,
+					retries: suite.retries,
+					configurations
+				};
+			});
+			const result = {
+				id: device.id,
+				name: device.name,
+				platform: device.platform,
+				suites
+			};
+			if (device.fixture) {
+				result.fixture = device.fixture;
+			}
+			return result;
+		});
+
+		return {
+			version: 1,
+			stats: {
+				suites: suiteNames.size,
+				tests: totalTests,
+				passes: totalPasses,
+				failures: totalFailures,
+				skipped: totalSkipped,
+				duration: totalDuration,
+				start: startTime,
+				end: endTime
+			},
+			devices: devicesArray
+		};
+	}
+
+	_extractSuiteInfo(test) {
+		let suite = test.parent;
+		let file = null;
+		let platformName = null;
+		let systemThread = null;
+		let systemMode = null;
+		let fixtureName = null;
+		let suiteName = null;
+		let retries = 0;
+		let fixtureObj = null;
+		// Walk the parent chain to find the outermost suite (direct child of root)
+		// That's the source suite whose title is the suite name for the report.
+		let outermostSuite = null;
+		while (suite) {
+			if (!outermostSuite) {
+				outermostSuite = suite;
+			}
+			if (suite.particle) {
+				if (suite.particle.file) {
+					file = suite.particle.file;
+				}
+				if (suite.particle.platform && !platformName) {
+					platformName = suite.particle.platform.name;
+				}
+				if (suite.particle.systemThread && !systemThread) {
+					systemThread = suite.particle.systemThread;
+				}
+				if (suite.particle.systemMode && !systemMode) {
+					systemMode = suite.particle.systemMode;
+				}
+				if (suite.particle.fixtures && suite.particle.fixtures.length && !fixtureName) {
+					fixtureObj = suite.particle.fixtures[0];
+					fixtureName = fixtureObj.name;
+				}
+				if (suite.particle.suiteRetries !== undefined) {
+					retries = suite.particle.suiteRetries;
+				}
+			}
+			if (!suite.parent || !suite.parent.parent) {
+				// suite is direct child of root (or root itself)
+				outermostSuite = suite;
+			}
+			suite = suite.parent;
+		}
+		if (outermostSuite) {
+			suiteName = outermostSuite.title;
+		}
+		if (test.particle && test.particle.suiteRetries !== undefined) {
+			retries = test.particle.suiteRetries;
+		}
+		const suitePath = file ? path.dirname(file) : null;
+		return { file, platform: platformName, systemThread, systemMode, fixture: fixtureName, suiteName: suiteName || '', suitePath, retries };
+	}
+}
+
+module.exports = { ReportBuilder };

--- a/lib/report-builder.test.js
+++ b/lib/report-builder.test.js
@@ -1,0 +1,270 @@
+'use strict';
+const { expect } = require('../test');
+const { ReportBuilder } = require('./report-builder');
+const Mocha = require('mocha');
+
+describe('ReportBuilder', () => {
+	describe('build()', () => {
+		it('groups tests by device into the final structure', () => {
+			const srcSuite = new Mocha.Suite('MySuite');
+			srcSuite.particle = { file: 'my_suite/my_suite.spec.js', suiteRetries: 0 };
+			const platSuite = new Mocha.Suite('boron');
+			platSuite.particle = { platform: { name: 'boron' }, fixtures: [], file: 'my_suite/my_suite.spec.js' };
+			const configSuite = new Mocha.Suite('systemThread=disabled');
+			configSuite.particle = { platform: { name: 'boron' }, systemThread: 'disabled', systemMode: 'semi-automatic', file: 'my_suite/my_suite.spec.js' };
+			configSuite.parent = platSuite;
+			platSuite.parent = srcSuite;
+
+			const allReportData = [{
+				start: '2026-04-16T10:00:00.000Z',
+				end: '2026-04-16T10:00:10.000Z',
+				attempt: 1,
+				tests: [{
+					name: 'test_a',
+					fullTitle: 'MySuite boron systemThread=disabled test_a',
+					state: 'passed',
+					duration: 500,
+					parent: configSuite,
+					particle: {
+						suiteRetries: 0,
+						devices: [{ id: 'dev1', name: 'boron-1', platform: 'boron' }]
+					}
+				}]
+			}];
+
+			const builder = new ReportBuilder();
+			const report = builder.build(allReportData);
+
+			expect(report.version).to.equal(1);
+			expect(report.stats.tests).to.equal(1);
+			expect(report.stats.passes).to.equal(1);
+			expect(report.stats.failures).to.equal(0);
+			expect(report.devices).to.have.length(1);
+			expect(report.devices[0].id).to.equal('dev1');
+			expect(report.devices[0].platform).to.equal('boron');
+			expect(report.devices[0].suites).to.have.length(1);
+			expect(report.devices[0].suites[0].name).to.equal('MySuite');
+			expect(report.devices[0].suites[0].path).to.equal('my_suite');
+			expect(report.devices[0].suites[0].configurations).to.have.length(1);
+			expect(report.devices[0].suites[0].configurations[0].systemThread).to.equal('disabled');
+			expect(report.devices[0].suites[0].configurations[0].attempts).to.have.length(1);
+			expect(report.devices[0].suites[0].configurations[0].attempts[0].passed).to.equal(true);
+		});
+
+		it('handles tests without device info using platform as fallback', () => {
+			const srcSuite = new Mocha.Suite('SuiteNoDevices');
+			srcSuite.particle = { file: 'nod/nod.spec.js', suiteRetries: 0 };
+			const platSuite = new Mocha.Suite('boron');
+			platSuite.particle = { platform: { name: 'boron' }, fixtures: [], file: 'nod/nod.spec.js' };
+			const configSuite = new Mocha.Suite('systemThread=enabled');
+			configSuite.particle = { platform: { name: 'boron' }, systemThread: 'enabled', systemMode: 'semi-automatic', file: 'nod/nod.spec.js' };
+			configSuite.parent = platSuite;
+			platSuite.parent = srcSuite;
+
+			const allReportData = [{
+				start: '2026-04-16T10:00:00.000Z',
+				end: '2026-04-16T10:00:10.000Z',
+				attempt: 1,
+				tests: [{
+					name: 'test_no_device',
+					fullTitle: 'SuiteNoDevices boron systemThread=enabled test_no_device',
+					state: 'failed',
+					duration: 300,
+					parent: configSuite,
+					particle: {
+						suiteRetries: 0
+					}
+				}]
+			}];
+
+			const builder = new ReportBuilder();
+			const report = builder.build(allReportData);
+
+			expect(report.stats.tests).to.equal(1);
+			expect(report.stats.failures).to.equal(1);
+			expect(report.devices).to.have.length(1);
+			expect(report.devices[0].id).to.equal('boron');
+			expect(report.devices[0].suites[0].configurations[0].attempts[0].passed).to.equal(false);
+		});
+
+		it('groups multiple attempts under the same configuration', () => {
+			const srcSuite = new Mocha.Suite('RetrySuite');
+			srcSuite.particle = { file: 'retry/retry.spec.js', suiteRetries: 2 };
+			const platSuite = new Mocha.Suite('boron');
+			platSuite.particle = { platform: { name: 'boron' }, fixtures: [], file: 'retry/retry.spec.js' };
+			const configSuite = new Mocha.Suite('systemThread=disabled');
+			configSuite.particle = { platform: { name: 'boron' }, systemThread: 'disabled', systemMode: 'semi-automatic', file: 'retry/retry.spec.js' };
+			configSuite.parent = platSuite;
+			platSuite.parent = srcSuite;
+
+			const allReportData = [
+				{
+					start: '2026-04-16T10:00:00.000Z',
+					end: '2026-04-16T10:00:10.000Z',
+					attempt: 1,
+					sourceSuite: 'RetrySuite',
+					tests: [{
+						name: 'test_retry',
+						fullTitle: 'RetrySuite boron systemThread=disabled test_retry',
+						state: 'failed',
+						duration: 100,
+						parent: configSuite,
+						particle: { suiteRetries: 2, devices: [{ id: 'd1', name: 'boron-1', platform: 'boron' }] }
+					}]
+				},
+				{
+					start: '2026-04-16T10:00:10.000Z',
+					end: '2026-04-16T10:00:20.000Z',
+					attempt: 2,
+					sourceSuite: 'RetrySuite',
+					tests: [{
+						name: 'test_retry',
+						fullTitle: 'RetrySuite boron systemThread=disabled test_retry',
+						state: 'passed',
+						duration: 80,
+						parent: configSuite,
+						particle: { suiteRetries: 2, devices: [{ id: 'd1', name: 'boron-1', platform: 'boron' }] }
+					}]
+				}
+			];
+
+			const builder = new ReportBuilder();
+			const report = builder.build(allReportData);
+
+			expect(report.stats.tests).to.equal(2);
+			expect(report.stats.passes).to.equal(1);
+			expect(report.stats.failures).to.equal(1);
+			const attempts = report.devices[0].suites[0].configurations[0].attempts;
+			expect(attempts).to.have.length(2);
+			expect(attempts[0].attempt).to.equal(1);
+			expect(attempts[0].passed).to.equal(false);
+			expect(attempts[1].attempt).to.equal(2);
+			expect(attempts[1].passed).to.equal(true);
+		});
+
+		it('handles empty report data', () => {
+			const builder = new ReportBuilder();
+			const report = builder.build([]);
+			expect(report.stats.tests).to.equal(0);
+			expect(report.devices).to.have.length(0);
+		});
+
+		it('handles skipped tests', () => {
+			const srcSuite = new Mocha.Suite('SkipSuite');
+			srcSuite.particle = { file: 'skip/skip.spec.js', suiteRetries: 0 };
+			const platSuite = new Mocha.Suite('argon');
+			platSuite.particle = { platform: { name: 'argon' }, fixtures: [], file: 'skip/skip.spec.js' };
+			const configSuite = new Mocha.Suite('systemThread=enabled');
+			configSuite.particle = { platform: { name: 'argon' }, systemThread: 'enabled', systemMode: 'semi-automatic', file: 'skip/skip.spec.js' };
+			configSuite.parent = platSuite;
+			platSuite.parent = srcSuite;
+
+			const allReportData = [{
+				start: '2026-04-16T10:00:00.000Z',
+				end: '2026-04-16T10:00:05.000Z',
+				attempt: 1,
+				tests: [{
+					name: 'test_skipped',
+					fullTitle: 'SkipSuite argon systemThread=enabled test_skipped',
+					state: 'skipped',
+					duration: 0,
+					parent: configSuite,
+					particle: { suiteRetries: 0, devices: [{ id: 'sk1', name: 'argon-1', platform: 'argon' }] }
+				}]
+			}];
+
+			const builder = new ReportBuilder();
+			const report = builder.build(allReportData);
+
+			expect(report.stats.skipped).to.equal(1);
+			expect(report.devices[0].suites[0].configurations[0].attempts[0].passed).to.equal(true);
+		});
+
+		it('groups tests from same suite across different configurations', () => {
+			const srcSuite = new Mocha.Suite('MultiConfigSuite');
+			srcSuite.particle = { file: 'multi/multi.spec.js', suiteRetries: 0 };
+			const platSuite = new Mocha.Suite('boron');
+			platSuite.particle = { platform: { name: 'boron' }, fixtures: [], file: 'multi/multi.spec.js' };
+
+			const configSuite1 = new Mocha.Suite('systemThread=enabled');
+			configSuite1.particle = { platform: { name: 'boron' }, systemThread: 'enabled', systemMode: 'semi-automatic', file: 'multi/multi.spec.js' };
+			configSuite1.parent = platSuite;
+
+			const configSuite2 = new Mocha.Suite('systemThread=disabled');
+			configSuite2.particle = { platform: { name: 'boron' }, systemThread: 'disabled', systemMode: 'semi-automatic', file: 'multi/multi.spec.js' };
+			configSuite2.parent = platSuite;
+
+			platSuite.parent = srcSuite;
+
+			const allReportData = [{
+				start: '2026-04-16T10:00:00.000Z',
+				end: '2026-04-16T10:00:20.000Z',
+				attempt: 1,
+				tests: [
+					{
+						name: 'test_thread_enabled',
+						fullTitle: 'MultiConfigSuite boron systemThread=enabled test_thread_enabled',
+						state: 'passed',
+						duration: 100,
+						parent: configSuite1,
+						particle: { suiteRetries: 0, devices: [{ id: 'd1', name: 'boron-1', platform: 'boron' }] }
+					},
+					{
+						name: 'test_thread_disabled',
+						fullTitle: 'MultiConfigSuite boron systemThread=disabled test_thread_disabled',
+						state: 'passed',
+						duration: 120,
+						parent: configSuite2,
+						particle: { suiteRetries: 0, devices: [{ id: 'd1', name: 'boron-1', platform: 'boron' }] }
+					}
+				]
+			}];
+
+			const builder = new ReportBuilder();
+			const report = builder.build(allReportData);
+
+			expect(report.stats.tests).to.equal(2);
+			expect(report.devices).to.have.length(1);
+			expect(report.devices[0].suites).to.have.length(1);
+			expect(report.devices[0].suites[0].configurations).to.have.length(2);
+		});
+	});
+
+	describe('_extractSuiteInfo()', () => {
+		it('walks up the suite hierarchy to extract metadata', () => {
+			const srcSuite = new Mocha.Suite('MySuite');
+			srcSuite.particle = { file: 'my_suite/my_suite.spec.js', suiteRetries: 3 };
+			const platSuite = new Mocha.Suite('boron');
+			platSuite.particle = { platform: { name: 'boron' }, fixtures: [{ name: 'myFixture' }], file: 'my_suite/my_suite.spec.js' };
+			const configSuite = new Mocha.Suite('systemThread=disabled');
+			configSuite.particle = { platform: { name: 'boron' }, systemThread: 'disabled', systemMode: 'semi-automatic', file: 'my_suite/my_suite.spec.js' };
+			configSuite.parent = platSuite;
+			platSuite.parent = srcSuite;
+
+			const builder = new ReportBuilder();
+			const result = builder._extractSuiteInfo({ parent: configSuite, particle: {} });
+
+			expect(result.file).to.equal('my_suite/my_suite.spec.js');
+			expect(result.suiteName).to.equal('MySuite');
+			expect(result.platform).to.equal('boron');
+			expect(result.systemThread).to.equal('disabled');
+			expect(result.systemMode).to.equal('semi-automatic');
+			expect(result.fixture).to.equal('myFixture');
+			expect(result.retries).to.equal(3);
+			expect(result.suitePath).to.equal('my_suite');
+		});
+
+		it('uses test.particle.suiteRetries as override', () => {
+			const srcSuite = new Mocha.Suite('Suite');
+			srcSuite.particle = { file: 'x/x.spec.js', suiteRetries: 1 };
+			const platSuite = new Mocha.Suite('argon');
+			platSuite.particle = { platform: { name: 'argon' }, fixtures: [], file: 'x/x.spec.js' };
+			platSuite.parent = srcSuite;
+
+			const builder = new ReportBuilder();
+			const result = builder._extractSuiteInfo({ parent: platSuite, particle: { suiteRetries: 5 } });
+
+			expect(result.retries).to.equal(5);
+		});
+	});
+});

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -1,0 +1,51 @@
+'use strict';
+
+const Mocha = require('mocha');
+const Spec = Mocha.reporters.Spec;
+const constants = Mocha.Runner.constants;
+
+const EVENT_TEST_PASS = constants.EVENT_TEST_PASS;
+const EVENT_TEST_FAIL = constants.EVENT_TEST_FAIL;
+const EVENT_TEST_PENDING = constants.EVENT_TEST_PENDING;
+const EVENT_RUN_END = constants.EVENT_RUN_END;
+
+class ReportReporter extends Spec {
+	constructor(runner, options) {
+		super(runner, options);
+		let reportData = null;
+		if (options) {
+			const reporterOpts = options.reporterOptions || options.reporterOption;
+			if (reporterOpts && reporterOpts.reportData) {
+				reportData = reporterOpts.reportData;
+			} else if (options.reportData) {
+				reportData = options.reportData;
+			}
+		}
+		this._reportData = reportData || { tests: [], start: null, end: null };
+
+		runner.on(EVENT_TEST_PASS, (test) => {
+			this._reportData.tests.push(test);
+		});
+
+		runner.on(EVENT_TEST_FAIL, (test) => {
+			this._reportData.tests.push(test);
+		});
+
+		runner.on(EVENT_TEST_PENDING, (test) => {
+			this._reportData.tests.push(test);
+		});
+
+		runner.on(EVENT_RUN_END, () => {
+			if (!this._reportData.start) {
+				this._reportData.start = new Date().toISOString();
+			}
+			this._reportData.end = new Date().toISOString();
+		});
+	}
+
+	get reportData() {
+		return this._reportData;
+	}
+}
+
+module.exports = { ReportReporter };

--- a/lib/reporter.test.js
+++ b/lib/reporter.test.js
@@ -1,0 +1,126 @@
+'use strict';
+const { expect } = require('../test');
+const { ReportReporter } = require('./reporter');
+const Mocha = require('mocha');
+const createStatsCollector = require('mocha/lib/stats-collector');
+
+describe('ReportReporter', () => {
+	let mocha;
+	let runner;
+	let suite;
+
+	beforeEach(() => {
+		mocha = new Mocha();
+		suite = new Mocha.Suite('root', mocha.suite.ctx);
+		runner = new Mocha.Runner(suite);
+		createStatsCollector(runner);
+	});
+
+	afterEach(() => {
+		runner = null;
+		mocha = null;
+	});
+
+	it('collects passing test data', () => {
+		const reportData = { tests: [], start: null, end: null };
+		new ReportReporter(runner, { reportData });
+		const parentSuite = new Mocha.Suite('parent suite');
+		parentSuite.ctx = mocha.suite.ctx;
+		suite.addSuite(parentSuite);
+		const test = new Mocha.Test('test title');
+		test.parent = parentSuite;
+		test.state = 'passed';
+		test.duration = 100;
+		test.particle = {};
+		runner.emit(Mocha.Runner.constants.EVENT_RUN_BEGIN);
+		runner.emit(Mocha.Runner.constants.EVENT_TEST_PASS, test);
+		runner.emit(Mocha.Runner.constants.EVENT_RUN_END);
+		expect(reportData.tests).to.have.length(1);
+		expect(reportData.tests[0].title).to.equal('test title');
+		expect(reportData.tests[0].state).to.equal('passed');
+		expect(reportData.tests[0].duration).to.equal(100);
+	});
+
+	it('collects failing test data with error', () => {
+		const reportData = { tests: [], start: null, end: null };
+		new ReportReporter(runner, { reportData });
+		const parentSuite = new Mocha.Suite('parent suite');
+		parentSuite.ctx = mocha.suite.ctx;
+		suite.addSuite(parentSuite);
+		const test = new Mocha.Test('failing test');
+		test.parent = parentSuite;
+		test.state = 'failed';
+		test.duration = 200;
+		test.particle = {};
+		const err = new Error('something went wrong');
+		test.err = err;
+		runner.emit(Mocha.Runner.constants.EVENT_RUN_BEGIN);
+		runner.emit(Mocha.Runner.constants.EVENT_TEST_FAIL, test, err);
+		runner.emit(Mocha.Runner.constants.EVENT_RUN_END);
+		expect(reportData.tests).to.have.length(1);
+		expect(reportData.tests[0].state).to.equal('failed');
+		expect(reportData.tests[0].err).to.have.property('message', 'something went wrong');
+	});
+
+	it('collects skipped test data', () => {
+		const reportData = { tests: [], start: null, end: null };
+		new ReportReporter(runner, { reportData });
+		const parentSuite = new Mocha.Suite('parent suite');
+		parentSuite.ctx = mocha.suite.ctx;
+		suite.addSuite(parentSuite);
+		const test = new Mocha.Test('skipped test');
+		test.parent = parentSuite;
+		test.state = 'skipped';
+		test.particle = {};
+		test.pending = true;
+		runner.emit(Mocha.Runner.constants.EVENT_RUN_BEGIN);
+		runner.emit(Mocha.Runner.constants.EVENT_TEST_PENDING, test);
+		runner.emit(Mocha.Runner.constants.EVENT_RUN_END);
+		expect(reportData.tests).to.have.length(1);
+		expect(reportData.tests[0].state).to.equal('skipped');
+	});
+
+	it('records end time on run end', () => {
+		const reportData = { tests: [], start: null, end: null };
+		new ReportReporter(runner, { reportData });
+		runner.emit(Mocha.Runner.constants.EVENT_RUN_BEGIN);
+		runner.emit(Mocha.Runner.constants.EVENT_RUN_END);
+		expect(reportData.end).to.be.a('string');
+		expect(new Date(reportData.end).getTime()).to.be.at.most(Date.now() + 1000);
+	});
+
+	it('preserves particle metadata on test objects', () => {
+		const reportData = { tests: [], start: null, end: null };
+		new ReportReporter(runner, { reportData });
+		const parentSuite = new Mocha.Suite('parent suite');
+		parentSuite.ctx = mocha.suite.ctx;
+		suite.addSuite(parentSuite);
+		const test = new Mocha.Test('device test');
+		test.parent = parentSuite;
+		test.state = 'passed';
+		test.duration = 50;
+		test.particle = {
+			devices: [{ id: 'abc123', name: 'boron-1', platform: { name: 'boron' } }],
+			deviceTestName: 'device_test',
+			suiteInitDuration: 500,
+			suiteRetries: 2
+		};
+		runner.emit(Mocha.Runner.constants.EVENT_RUN_BEGIN);
+		runner.emit(Mocha.Runner.constants.EVENT_TEST_PASS, test);
+		runner.emit(Mocha.Runner.constants.EVENT_RUN_END);
+		expect(reportData.tests[0].title).to.equal('device test');
+		expect(reportData.tests[0].state).to.equal('passed');
+		expect(reportData.tests[0].duration).to.equal(50);
+		expect(reportData.tests[0].particle).to.deep.include({
+			deviceTestName: 'device_test',
+			suiteRetries: 2
+		});
+		expect(reportData.tests[0].particle.devices[0].id).to.equal('abc123');
+	});
+
+	it('inherits from Spec reporter', () => {
+		const reportData = { tests: [], start: null, end: null };
+		const reporter = new ReportReporter(runner, { reportData });
+		expect(reporter).to.be.an.instanceof(Mocha.reporters.Spec);
+	});
+});

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -8,12 +8,16 @@ const { RunMode, OutputFormat, config, APP_NAME } = require('./config');
 const { findTestName, shortenRight } = require('./util');
 const { InternalError, isInternalError } = require('./error');
 const globals = require('./globals');
+const { ReportReporter } = require('./reporter');
+const { ReportBuilder } = require('./report-builder');
 
 const Mocha = require('mocha');
+const createStatsCollector = require('mocha/lib/stats-collector');
 const glob = require('glob');
 const mkdirp = require('mkdirp');
 const tmp = require('tmp');
 const _ = require('lodash');
+const { default: chalk } = require('chalk');
 
 const fs = require('fs');
 const path = require('path');
@@ -285,35 +289,80 @@ class Runner {
 		};
 	}
 
-	async _runSuites(sourceSuites) {
+	async _runSuites(sourceSuites, { collectFailures = false, collectReport = false } = {}) {
 		const ctx = this._mocha.suite.ctx;
 		ctx.particle = this._createRunContext();
 		this._log.verbose('Generating test matrix');
 		await this._initTestMatrix(sourceSuites);
 		this._log.verbose('Running tests');
+		const failures = [];
+		const reportData = collectReport ? { tests: [], start: null, end: null } : null;
+		if (collectReport) {
+			this._mocha.reporter(ReportReporter, { reportData });
+		} else {
+			this._mocha.reporter('spec');
+		}
 		return new Promise(resolve => {
 			const runner = this._mocha.run(failureCount => {
-				resolve(!failureCount);
+				const stats = runner.stats || {};
+				resolve({ ok: !failureCount, failures, reportData, stats });
 			});
 			this._initMochaRunner(runner);
+			if (collectFailures) {
+				runner.on(MochaRunner.constants.EVENT_TEST_FAIL, (test) => {
+					failures.push(test);
+				});
+			}
 		});
 	}
 
 	async _runWithSuiteRetries() {
 		const plan = this._createSuiteRetryPlan();
 		let ok = true;
+		const retryFailures = [];
+		const allReportData = [];
+		const collectReport = !!config.get('reportFile');
+		const stats = { passes: 0, failures: 0, pending: 0, duration: 0 };
+		const allFailures = [];
 		await this._initRuntime();
 		try {
 			for (const suite of plan) {
 				let suiteOk = false;
+				let totalAttempts = 0;
+				const suiteFailures = [];
+				let lastResult = null;
 				for (let attempt = 0; attempt <= suite.retries; ++attempt) {
-					suiteOk = await this._runSuites([suite.suite]);
+					totalAttempts = attempt + 1;
+					const collectFailures = suite.retries > 0;
+					const result = await this._runSuites([suite.suite], { collectFailures, collectReport });
+					lastResult = result;
+					suiteOk = result.ok;
+					if (collectFailures && result.failures.length) {
+						suiteFailures.push({ attempt: totalAttempts, failureCount: result.failures.length, failures: result.failures });
+						for (const test of result.failures) {
+							allFailures.push(test);
+						}
+					}
+					if (collectReport && result.reportData) {
+						result.reportData.attempt = totalAttempts;
+						result.reportData.sourceSuite = suite.suite.title;
+						allReportData.push(result.reportData);
+					}
 					if (suiteOk) {
 						break;
 					}
 					if (attempt < suite.retries) {
 						this._log.warn(`Retrying suite: ${suite.suite.title} (${attempt + 1}/${suite.retries})`);
 					}
+				}
+				if (lastResult) {
+					stats.passes += lastResult.stats.passes || 0;
+					stats.failures += lastResult.stats.failures || 0;
+					stats.pending += lastResult.stats.pending || 0;
+					stats.duration += lastResult.stats.duration || 0;
+				}
+				if (suiteFailures.length) {
+					retryFailures.push({ suite: suite.suite, suiteOk, totalAttempts, suiteFailures });
 				}
 				if (!suiteOk) {
 					ok = false;
@@ -322,16 +371,84 @@ class Runner {
 		} finally {
 			await this._shutdownRuntime();
 		}
+		this._printRetrySummary(retryFailures, allFailures);
+		this._printSummary(stats);
+		if (collectReport && allReportData.length) {
+			this._writeReport(allReportData);
+		}
 		return ok;
 	}
 
 	async _run() {
 		await this._initRuntime();
 		try {
-			return await this._runSuites(this._sourceSuites);
+			const collectReport = !!config.get('reportFile');
+			const result = await this._runSuites(this._sourceSuites, { collectReport });
+			if (collectReport && result.reportData) {
+				result.reportData.attempt = 1;
+				this._writeReport([result.reportData]);
+			}
+			return result.ok;
 		} finally {
 			await this._shutdownRuntime();
 		}
+	}
+
+	_printRetrySummary(retryFailures, allFailures) {
+		if (!retryFailures.length) {
+			return;
+		}
+		const Base = Mocha.reporters.Base;
+		const color = Base.color;
+		console.log();
+		console.log(chalk.bold('Retried suites:'));
+		for (const { suite, suiteOk, totalAttempts, suiteFailures } of retryFailures) {
+			const status = suiteOk
+				? color('green', 'pass')
+				: color('fail', 'fail');
+			const retryInfo = totalAttempts > 1
+				? ` (took ${totalAttempts} attempts)`
+				: '';
+			const failedAttempts = suiteFailures.filter(a => a.failureCount > 0);
+			const attemptsInfo = failedAttempts.length
+				? ` - ${failedAttempts.map(a => color('fail', `${a.failureCount} failed`)).join(', ')}`
+				: '';
+			console.log(`  ${suite.title}: ${status}${retryInfo}${attemptsInfo}`);
+		}
+		console.log();
+		if (allFailures && allFailures.length) {
+			Base.list(allFailures);
+		}
+	}
+
+	_printSummary(stats) {
+		const runner = new MochaRunner(new MochaSuite(''));
+		createStatsCollector(runner);
+		runner.stats = {
+			suites: 0,
+			tests: (stats.passes || 0) + (stats.failures || 0) + (stats.pending || 0),
+			passes: stats.passes || 0,
+			pending: stats.pending || 0,
+			failures: stats.failures || 0,
+			start: new Date(),
+			end: new Date(),
+			duration: stats.duration || 0
+		};
+		const reporter = new Mocha.reporters.Spec(runner);
+		reporter.failures = [];
+		reporter.epilogue();
+	}
+
+	_writeReport(allReportData) {
+		const reportFile = config.get('reportFile');
+		if (!reportFile || !allReportData || !allReportData.length) {
+			return;
+		}
+		const builder = new ReportBuilder();
+		const report = builder.build(allReportData);
+		this._log.verbose(`Writing report to ${reportFile}`);
+		mkdirp.sync(path.dirname(reportFile));
+		fs.writeFileSync(reportFile, JSON.stringify(report, null, 2));
 	}
 
 	async _build() {
@@ -475,8 +592,12 @@ class Runner {
 			this._currentTest = test;
 			this._log.indent();
 			test.particle.startTime = Date.now();
+			test.particle.originalTitle = test.title;
 		};
 		const testEnd = () => {
+			if (this._currentTest && this._currentTest.particle && this._currentTest.particle.startTime) {
+				this._currentTest.particle.endTime = Date.now();
+			}
 			this._log.unindent();
 			this._currentTest = null;
 		};
@@ -525,7 +646,7 @@ class Runner {
 				continue;
 			}
 			const file = particle.file;
-			const newSuite = srcSuite.clone(); // Doesn't copy tests and hooks
+			const newSuite = srcSuite.clone(); // Doesn't copy tests, hooks, or particle
 			let platformsByFixture = this._devMgr.getPlatformsForFixtures(particle.fixtures);
 			let platforms = particle.platforms;
 			if (platformsByFixture && platformsByFixture.length > 1) {
@@ -553,7 +674,8 @@ class Runner {
 				platformSuite.particle = {
 					platform,
 					fixtures: particle.fixtures,
-					file
+					file,
+					suiteRetries: particle.suiteRetries
 				};
 				const suiteWrapper = this._initPlatformSuite(platformSuite);
 				// Create a nested suite for each combination of the remaining parameters
@@ -591,7 +713,9 @@ class Runner {
 								continue;
 							}
 							const test = srcTest.clone();
-							test.particle = {};
+							test.particle = {
+								suiteRetries: particle.suiteRetries
+							};
 							suite.addTest(test);
 						}
 						if (!suite.tests.length) {
@@ -666,7 +790,8 @@ class Runner {
 				const test = new MochaTest(testName, () => {});
 				test.particle = {
 					devices: deviceTests.get(testName),
-					deviceTestName: testName
+					deviceTestName: testName,
+					suiteRetries: platformSuite.particle.suiteRetries || 0
 				};
 				suite.addTest(test);
 			}

--- a/lib/runner.test.js
+++ b/lib/runner.test.js
@@ -2,6 +2,7 @@
 const { expect, config, log, fixturePath } = require('../test');
 const proxyquire = require('proxyquire');
 const { Runner } = proxyquire('../lib/runner', { './config': { config } });
+const { ReportBuilder } = require('./report-builder');
 const { RunMode } = require('./config');
 
 const sinon = require('sinon');
@@ -69,10 +70,13 @@ describe('Runner', () => {
 			];
 			const initRuntimeStub = sinon.stub(runner, '_initRuntime').resolves();
 			const shutdownRuntimeStub = sinon.stub(runner, '_shutdownRuntime').resolves();
+			const printRetrySummaryStub = sinon.stub(runner, '_printRetrySummary');
+			const printSummaryStub = sinon.stub(runner, '_printSummary');
 			const runSuitesStub = sinon.stub(runner, '_runSuites');
-			runSuitesStub.onCall(0).resolves(false);
-			runSuitesStub.onCall(1).resolves(true);
-			runSuitesStub.onCall(2).resolves(true);
+			const failure = Object.assign(new Error('test fail'), { title: 'test_01' });
+			runSuitesStub.onCall(0).resolves({ ok: false, failures: [failure], reportData: null, stats: { passes: 0, failures: 1, pending: 0, duration: 1000 } });
+			runSuitesStub.onCall(1).resolves({ ok: true, failures: [], reportData: null, stats: { passes: 1, failures: 0, pending: 0, duration: 500 } });
+			runSuitesStub.onCall(2).resolves({ ok: true, failures: [], reportData: null, stats: { passes: 20, failures: 0, pending: 0, duration: 45000 } });
 
 			const ok = await runner._runWithSuiteRetries();
 
@@ -80,6 +84,107 @@ describe('Runner', () => {
 			expect(initRuntimeStub.callCount).to.equal(1);
 			expect(shutdownRuntimeStub.callCount).to.equal(1);
 			expect(runSuitesStub.getCalls().map(call => call.args[0][0].title)).to.deep.equal(['suite_01', 'suite_01', 'suite_02']);
+			expect(printRetrySummaryStub.callCount).to.equal(1);
+			expect(printRetrySummaryStub.firstCall.args[0]).to.have.length(1);
+			expect(printRetrySummaryStub.firstCall.args[0][0].suite.title).to.equal('suite_01');
+			expect(printSummaryStub.callCount).to.equal(1);
+			expect(printSummaryStub.firstCall.args[0]).to.deep.equal({ passes: 21, failures: 0, pending: 0, duration: 45500 });
+			expect(printRetrySummaryStub.firstCall.args[1]).to.have.length(1);
+		});
+
+		it('writes report when reportFile is configured and suite has retries', async () => {
+			config.set('reportFile', '/tmp/test-report.json');
+			runner._sourceSuites = [
+				{ title: 'suite_01', particle: { file: 'suite_01/suite_01.spec.js', exclude: false, suiteRetries: 1 } }
+			];
+			sinon.stub(runner, '_initRuntime').resolves();
+			sinon.stub(runner, '_shutdownRuntime').resolves();
+			sinon.stub(runner, '_printRetrySummary');
+			sinon.stub(runner, '_printSummary');
+			const writeReportStub = sinon.stub(runner, '_writeReport');
+			const runSuitesStub = sinon.stub(runner, '_runSuites');
+			runSuitesStub.onCall(0).resolves({ ok: false, failures: [], reportData: { tests: [{ name: 't1', state: 'failed' }], start: '2026-04-16T10:00:00.000Z', end: '2026-04-16T10:00:10.000Z' }, stats: { passes: 0, failures: 1, pending: 0, duration: 10000 } });
+			runSuitesStub.onCall(1).resolves({ ok: true, failures: [], reportData: { tests: [{ name: 't1', state: 'passed' }], start: '2026-04-16T10:00:10.000Z', end: '2026-04-16T10:00:20.000Z' }, stats: { passes: 1, failures: 0, pending: 0, duration: 5000 } });
+
+			await runner._runWithSuiteRetries();
+
+			expect(writeReportStub.callCount).to.equal(1);
+			expect(writeReportStub.firstCall.args[0]).to.have.length(2);
+		});
+	});
+
+	describe('_run()', () => {
+		it('writes report when reportFile is configured', async () => {
+			config.set('reportFile', '/tmp/test-report.json');
+			sinon.stub(runner, '_initRuntime').resolves();
+			sinon.stub(runner, '_shutdownRuntime').resolves();
+			const writeReportStub = sinon.stub(runner, '_writeReport');
+			sinon.stub(runner, '_runSuites').resolves({ ok: true, failures: [], reportData: { tests: [], start: '2026-04-16T10:00:00.000Z', end: '2026-04-16T10:00:10.000Z' }, stats: { passes: 0, failures: 0, pending: 0, duration: 0 } });
+
+			await runner._run();
+
+			expect(writeReportStub.callCount).to.equal(1);
+		});
+
+		it('does not write report when reportFile is not set', async () => {
+			config.set('reportFile', '');
+			sinon.stub(runner, '_initRuntime').resolves();
+			sinon.stub(runner, '_shutdownRuntime').resolves();
+			const writeReportStub = sinon.stub(runner, '_writeReport');
+			sinon.stub(runner, '_runSuites').resolves({ ok: true, failures: [], reportData: null, stats: { passes: 0, failures: 0, pending: 0, duration: 0 } });
+
+			await runner._run();
+
+			expect(writeReportStub.callCount).to.equal(0);
+		});
+	});
+
+	describe('ReportBuilder', () => {
+		it('groups tests by device into the final structure', () => {
+			const MochaSuite = require('mocha').Suite;
+			const srcSuite = new MochaSuite('MySuite');
+			srcSuite.particle = { file: 'my_suite/my_suite.spec.js', suiteRetries: 0 };
+			const platSuite = new MochaSuite('boron');
+			platSuite.particle = { platform: { name: 'boron' }, fixtures: [], file: 'my_suite/my_suite.spec.js' };
+			const configSuite = new MochaSuite('systemThread=disabled');
+			configSuite.particle = { platform: { name: 'boron' }, systemThread: 'disabled', systemMode: 'semi-automatic', file: 'my_suite/my_suite.spec.js' };
+			configSuite.parent = platSuite;
+			platSuite.parent = srcSuite;
+
+			const allReportData = [{
+				start: '2026-04-16T10:00:00.000Z',
+				end: '2026-04-16T10:00:10.000Z',
+				attempt: 1,
+				tests: [{
+					name: 'test_a',
+					fullTitle: 'MySuite boron systemThread=disabled test_a',
+					state: 'passed',
+					duration: 500,
+					parent: configSuite,
+					particle: {
+						suiteRetries: 0,
+						devices: [{ id: 'dev1', name: 'boron-1', platform: 'boron' }]
+					}
+				}]
+			}];
+
+			const builder = new ReportBuilder();
+			const report = builder.build(allReportData);
+
+			expect(report.version).to.equal(1);
+			expect(report.stats.tests).to.equal(1);
+			expect(report.stats.passes).to.equal(1);
+			expect(report.stats.failures).to.equal(0);
+			expect(report.devices).to.have.length(1);
+			expect(report.devices[0].id).to.equal('dev1');
+			expect(report.devices[0].platform).to.equal('boron');
+			expect(report.devices[0].suites).to.have.length(1);
+			expect(report.devices[0].suites[0].name).to.equal('MySuite');
+			expect(report.devices[0].suites[0].path).to.equal('my_suite');
+			expect(report.devices[0].suites[0].configurations).to.have.length(1);
+			expect(report.devices[0].suites[0].configurations[0].systemThread).to.equal('disabled');
+			expect(report.devices[0].suites[0].configurations[0].attempts).to.have.length(1);
+			expect(report.devices[0].suites[0].configurations[0].attempts[0].passed).to.equal(true);
 		});
 	});
 });


### PR DESCRIPTION
### Detailed mocha summary after retries

When --suite-retries are enabled adds proper summary at the end including the errors that occurred during retries (even if suite with retries successfully passed):

```
Retried suites:
  Cloud events: pass (took 2 attempts) - 11 failed


  1) Cloud events
       p2
         systemThread=disabled
           publish_device_to_cloud_event_with_content_type:
     IN control transfer failed
  

  2) Cloud events
       p2
         systemThread=disabled
           publish_device_to_cloud_event_as_variant:
     Assertion failed: (Particle.connected()=0) == (true=1), file tests/integration/communication/events/events.cpp, line 71.
  

  3) Cloud events
       p2
         systemThread=disabled
           validate_cloud_to_device_event_with_content_type:
     Unexpected test status: 5
  

  4) Cloud events
       p2
         systemThread=disabled
           validate_cloud_to_device_event_with_cbor_data:
     IN control transfer failed
  

  5) Cloud events
       p2
         systemThread=enabled
           particle_publish_publishes_an_event:
     IN control transfer failed
  

  6) Cloud events
       p2
         systemThread=enabled
           get_max_event_data_size:
     Assertion failed: (Particle.connected()=0) == (true=1), file tests/integration/communication/events/events.cpp, line 50.
  

  7) Cloud events
       p2
         systemThread=enabled
           verify_max_event_data_size:
     Assertion failed: (Particle.connected()=0) == (true=1), file tests/integration/communication/events/events.cpp, line 57.
  

  8) Cloud events
       p2
         systemThread=enabled
           publish_device_to_cloud_event_with_content_type:
     Assertion failed: (Particle.connected()=0) == (true=1), file tests/integration/communication/events/events.cpp, line 63.
  

  9) Cloud events
       p2
         systemThread=enabled
           publish_device_to_cloud_event_as_variant:
     Assertion failed: (Particle.connected()=0) == (true=1), file tests/integration/communication/events/events.cpp, line 71.
  

  10) Cloud events
       p2
         systemThread=enabled
           validate_cloud_to_device_event_with_content_type:
     IN control transfer failed
  

  11) Cloud events
       p2
         systemThread=enabled
           validate_cloud_to_device_event_with_cbor_data:
     IN control transfer failed
  


  20 passing (1m)

```

### JSON reports

`-r file.json` generates a detailed JSON report of devices/suites/tests/retries/errors etc

example:
```
{
  "version": 1,
  "stats": {
    "suites": 2,
    "tests": 31,
    "passes": 27,
    "failures": 4,
    "skipped": 0,
    "duration": 3796,
    "start": "2026-04-16T19:04:04.860Z",
    "end": "2026-04-16T19:04:04.861Z"
  },
  "devices": [
    {
      "id": "23123123123123",
      "name": null,
      "platform": "p2",
      "suites": [
        {
          "name": "00_before: Preparation/Setup for HIL Testing",
          "path": "00_before",
          "file": "00_before/before.spec.js",
          "retries": 0,
          "configurations": [
            {
              "systemThread": "enabled",
              "systemMode": "semi-automatic",
              "attempts": [
                {
                  "attempt": 1,
                  "passed": true,
                  "tests": [
                    {
                      "name": "01_erase_factory_module",
                      "duration": 5079,
                      "state": "passed"
                    },
                    {
                      "name": "02_remove_static_ip",
                      "duration": 410,
                      "state": "passed"
                    },
                    {
                      "name": "03_enable_listening_mode",
                      "duration": 408,
                      "state": "passed"
                    },
                    {
                      "name": "04_clear_env",
                      "duration": 569,
                      "state": "passed"
                    },
                    {
                      "name": "05_restore_cloud_after_env_clear",
                      "duration": 277,
                      "state": "passed"
                    },
                    {
                      "name": "06_finalize_env_clear",
                      "duration": 3880,
                      "state": "passed"
                    },
                    {
                      "name": "07_disable_external_rtc",
                      "duration": 3532,
                      "state": "passed"
                    },
                    {
                      "name": "08_verify_external_rtc_default_state",
                      "duration": 412,
                      "state": "passed"
                    },
                    {
                      "name": "09_report_muon_presence",
                      "duration": 1,
                      "state": "passed"
                    },
                    {
                      "name": "10_configure_muon_board_and_exrtc",
                      "duration": 409,
                      "state": "passed"
                    },
                    {
                      "name": "11_verify_muon_exrtc_configuration",
                      "duration": 407,
                      "state": "passed"
                    }
                  ]
                }
              ]
            }
          ]
        },
        {
          "name": "Cloud events",
          "path": "communication/events",
          "file": "communication/events/events.spec.js",
          "retries": 0,
          "configurations": [
            {
              "systemThread": "disabled",
              "systemMode": "semi-automatic",
              "attempts": [
                {
                  "attempt": 1,
                  "passed": false,
                  "tests": [
                    {
                      "name": "connect",
                      "duration": 19328,
                      "state": "passed"
                    },
                    {
                      "name": "particle_publish_publishes_an_event",
                      "duration": 1019,
                      "state": "passed"
                    },
                    {
                      "name": "get_max_event_data_size",
                      "duration": 1017,
                      "state": "passed"
                    },
                    {
                      "name": "verify_max_event_data_size",
                      "duration": 1015,
                      "state": "passed"
                    },
                    {
                      "name": "publish_device_to_cloud_event_with_content_type",
                      "duration": 13599,
                      "state": "failed",
                      "err": {
                        "message": "Unexpected test status: 5",
                        "stack": ""
                      }
                    },
                    {
                      "name": "publish_device_to_cloud_event_as_variant",
                      "duration": 8780,
                      "state": "failed",
                      "err": {
                        "message": "Assertion failed: (Particle.connected()=0) == (true=1), file tests/integration/communication/events/events.cpp, line 71.",
                        "stack": ""
                      }
                    },
                    {
                      "name": "publish_cloud_to_device_event_with_content_type",
                      "duration": 1200,
                      "state": "passed"
                    },
                    {
                      "name": "validate_cloud_to_device_event_with_content_type",
                      "duration": 22548,
                      "state": "failed",
                      "err": {
                        "message": "Unexpected test status: 5",
                        "stack": ""
                      }
                    },
                    {
                      "name": "publish_cloud_to_device_event_with_cbor_data",
                      "duration": 870,
                      "state": "passed"
                    },
                    {
                      "name": "validate_cloud_to_device_event_with_cbor_data",
                      "duration": 60656,
                      "state": "failed",
                      "err": {
                        "message": "Assertion failed: (System.waitCondition([]{ return ([]() { return eventReceived; })(); }, (60000))=0) == (true=1), file tests/integration/communication/events/events.cpp, line 94.",
                        "stack": ""
                      }
                    }
                  ]
                }
              ]
            },
            {
              "systemThread": "enabled",
              "systemMode": "semi-automatic",
              "attempts": [
                {
                  "attempt": 1,
                  "passed": true,
                  "tests": [
                    {
                      "name": "connect",
                      "duration": 22117,
                      "state": "passed"
                    },
                    {
                      "name": "particle_publish_publishes_an_event",
                      "duration": 1,
                      "state": "passed"
                    },
                    {
                      "name": "get_max_event_data_size",
                      "duration": 1,
                      "state": "passed"
                    },
                    {
                      "name": "verify_max_event_data_size",
                      "duration": 1018,
                      "state": "passed"
                    },
                    {
                      "name": "publish_device_to_cloud_event_with_content_type",
                      "duration": 1,
                      "state": "passed"
                    },
                    {
                      "name": "publish_device_to_cloud_event_as_variant",
                      "duration": 1,
                      "state": "passed"
                    },
                    {
                      "name": "publish_cloud_to_device_event_with_content_type",
                      "duration": 661,
                      "state": "passed"
                    },
                    {
                      "name": "validate_cloud_to_device_event_with_content_type",
                      "duration": 1017,
                      "state": "passed"
                    },
                    {
                      "name": "publish_cloud_to_device_event_with_cbor_data",
                      "duration": 213,
                      "state": "passed"
                    },
                    {
                      "name": "validate_cloud_to_device_event_with_cbor_data",
                      "duration": 1,
                      "state": "passed"
                    }
                  ]
                }
              ]
            }
          ]
        }
      ]
    }
  ]
}
```